### PR TITLE
Reverted sails-permissions to 1.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sails": "~0.11.0",
     "sails-auth": "^1.3.1",
     "sails-disk": "~0.10.0",
-    "sails-permissions": "latest",
+    "sails-permissions": "^1.4.5",
     "winston": "^1.0.1"
   },
   "scripts": {

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -9,6 +9,7 @@ html(lang="en")
         // SCRIPTS END
 
         // STYLES
+        link(rel="stylesheet", href="/styles/importer.css")
         link(rel="stylesheet", href="/styles/style.css")
         // STYLES END
 


### PR DESCRIPTION
Seems like it is not compatible with version 2.x in some way, lifted server after reverting to 1.4.5 and it seems to have worked.

Let's get it up to date then? :)